### PR TITLE
Fix addBuildLink to include newlines

### DIFF
--- a/src/main/java/com/uber/jenkins/phabricator/CommentBuilder.java
+++ b/src/main/java/com/uber/jenkins/phabricator/CommentBuilder.java
@@ -157,7 +157,7 @@ class CommentBuilder {
      * Add a build link to the comment
      */
     public void addBuildLink() {
-        comment.append(String.format(" %s for more details.", buildURL));
+        comment.append(String.format("\n\nSee %s for more details.", buildURL));
     }
 
     /**


### PR DESCRIPTION
Currently, the comment looks something like:
```
Build was aborted https://jenkins.domain/job/project/build/ for more details.
```

With this change, it becomes:
```
Build was aborted

See https://jenkins.domain/job/project/build/ for more details.
```

This seems to match `addBuildFailureMessage`'s behavior more closely.